### PR TITLE
Align node-icon

### DIFF
--- a/styles/icons.less
+++ b/styles/icons.less
@@ -145,7 +145,7 @@
 
 .ionic-icon { .icons-xd; content: "\f14b"; }
 .haml-icon  { .icons-xd; content: "\f15b"; font-size: 15px; }
-.node-icon  { .icons-xd; content: "\f17b"; }
+.node-icon  { .icons-xd; content: "\f17b"; top: 6px; }
 .nginx-icon { .icons-xd; content: "\f146b"; font-size: 15px; }
 
 // File Icons, custom


### PR DESCRIPTION
Since the icon is pretty small in height, top should be a bit lower.

Before:
<img width="193" alt="screen shot 2015-10-19 at 12 06 06" src="https://cloud.githubusercontent.com/assets/4569111/10576237/a8eee454-7659-11e5-8c27-50e897c3279a.png">

After:
<img width="193" alt="screen shot 2015-10-19 at 12 05 53" src="https://cloud.githubusercontent.com/assets/4569111/10576242/ad8826b0-7659-11e5-899e-70ba7be8d166.png">
